### PR TITLE
fix: fix issues due to NodeList iterations in consuming projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 	],
 	"license": "MIT",
 	"devDependencies": {
-		"@wessberg/rollup-plugin-ts": "1.1.73",
+		"@wessberg/rollup-plugin-ts": "1.2.24",
 		"@wessberg/scaffold": "1.0.19",
 		"@wessberg/ts-config": "^0.0.41",
 		"rollup": "^1.26.0",

--- a/src/util/next-microtask.ts
+++ b/src/util/next-microtask.ts
@@ -2,7 +2,7 @@
  * Enqueues the given function for the next microtask
  * @param {CallableFunction} func
  */
-export const nextMicrotask = (func: CallableFunction): void => {
+export const nextMicrotask = (func: VoidFunction): void => {
 	if (typeof queueMicrotask !== "undefined") queueMicrotask(func);
 	else if (typeof Promise !== "undefined") Promise.resolve().then(() => func());
 	else setTimeout(() => func(), 0);

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -4,6 +4,8 @@
 		"src/**/*.*"
 	],
 	"compilerOptions": {
-		"declaration": true
+		"target": "es5",
+		"declaration": true,
+		"downlevelIteration": true
 	}
 }


### PR DESCRIPTION
This PR addresses some issues in consuming projects that arise from the fact that the library internally transforms NodeLists into Arrays via destructuring which doesn't work out on the consuming end without certain compiler options. Instead of forcing consumers to adjust their compiler options, the library itself should be published in the most compatible form.